### PR TITLE
Fix issues with servoWrite & pwmWrite

### DIFF
--- a/dist/spark.js
+++ b/dist/spark.js
@@ -81,7 +81,7 @@
         return restler.post("https://api.spark.io/v1/devices/" + this.deviceId + "/analogwrite", {
           data: {
             access_token: this.accessToken,
-            params: "" + pin + "," + (this.pinVal(value))
+            params: "" + pin + "," + value
           }
         });
       };

--- a/src/spark.coffee
+++ b/src/spark.coffee
@@ -46,7 +46,7 @@ namespace "Cylon.Adaptor", ->
 
     analogWrite: (pin, value) =>
       restler.post "https://api.spark.io/v1/devices/#{@deviceId}/analogwrite",
-                   data: { access_token: @accessToken, params: "#{pin},#{this.pinVal(value)}"}
+                   data: { access_token: @accessToken, params: "#{pin},#{value}"}
 
     pwmWrite: (pin, value) ->
       @analogWrite pin, value


### PR DESCRIPTION
I was hitting this error when trying to control my servo:

```
Servo on pin A0 turning counter clockwise

/Users/skalnik/github/catbot/node_modules/cylon-spark/dist/spark.js:94
        return analogWrite(pin, value);
               ^
ReferenceError: analogWrite is not defined
  at Spark.Spark.servoWrite (/Users/skalnik/github/catbot/node_modules/cylon-spark/dist/spark.js:94:16)
  at Connection.base.(anonymous function) [as servoWrite] (/Users/skalnik/github/catbot/node_modules/cylon-gpio/node_modules/cylon/dist/utils.js:33:31)
  at Servo.Servo.counterClockwise (/Users/skalnik/github/catbot/node_modules/cylon-gpio/dist/servo.js:71:34)
  at Device.base.(anonymous function) [as counterClockwise] (/Users/skalnik/github/catbot/node_modules/cylon-gpio/node_modules/cylon/dist/utils.js:33:31)
  at [object Object].<anonymous> (/Users/skalnik/github/catbot/catbot-cylon.coffee:16:9, <js>:25:26)
  at [object Object].wrapper [as _onTimeout] (timers.js:252:14)
  at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
```

It seems like someone forgot an `@` :smile:
